### PR TITLE
fix(index.tsx): Remove Purchase Button From Standard Plan

### DIFF
--- a/src/components/Home/Features/index.tsx
+++ b/src/components/Home/Features/index.tsx
@@ -64,9 +64,12 @@ const PricingSection = () => {
                   </li>
                 ))}
               </ul>
+              {plan.name !== "Standard" && (
               <button className="py-3 px-6 bg-primary hover:bg-blue-700 text-white rounded-lg">
-                Purchase Now
+              Purchase Now
               </button>
+              )}
+
             </div>
           ))}
         </div>


### PR DESCRIPTION
I removed the purchase button from the standard plan, as it will be free and not need to be purchased, this fixes #8 